### PR TITLE
Add Instagram and Spotify tracker params

### DIFF
--- a/_data/params.csv
+++ b/_data/params.csv
@@ -70,3 +70,5 @@ mkrid, eBay, https://partnerhelp.ebay.com/helpcenter/s/article/What-are-the-para
 campid, eBay, https://partnerhelp.ebay.com/helpcenter/s/article/What-are-the-parameters-of-an-EPN-link#tracking-link-format, No
 toolid, eBay, https://partnerhelp.ebay.com/helpcenter/s/article/What-are-the-parameters-of-an-EPN-link#tracking-link-format, No
 customid, eBay, https://partnerhelp.ebay.com/helpcenter/s/article/What-are-the-parameters-of-an-EPN-link#tracking-link-format, No
+igshid, Instagram, https://github.com/brave/brave-browser/issues/11580,
+si, Spotify, https://community.spotify.com/t5/Desktop-Windows/si-Parameter-in-Spotify-URL-s/td-p/4538290,


### PR DESCRIPTION


Thanks for this list! I knew I had forgotten about a few of the lesser-used utms.

I'm contributing Instagram and Spotify tracker params that I have added to my Firefox privacy.query_stripping.strip_list.

I love how the Spotify employee says "While we don't have any additional information about this at the moment..." while basically confirming that it's a per-track sharing tracker.

I couldn't find any proof of the Instagram tracker other than Brave's discussion of it, but that seemed legit enough.
