### PR TITLE
Added ndclid, ScCid, utm_source_platform, utm_marketing_tactic, utm_creative_format, _gl. Updated utm_* metadata

### DIFF
--- a/_data/params.csv
+++ b/_data/params.csv
@@ -7,13 +7,17 @@ gbraid, Google AdWords,https://support.google.com/google-ads/answer/10417364,
 wbraid, Google AdWords,https://support.google.com/google-ads/answer/10417364,
 twclid, Twitter,https://business.twitter.com/en/help/campaign-measurement-and-analytics/conversion-tracking-for-websites.html,
 yclid, Yahoo,https://ads-help.yahoo-net.jp/s/article/H000044650,
-utm_content, Google Analytics,,
-utm_term, Google Analytics,,
-utm_campaign, Google Analytics,,
-utm_medium, Google Analytics,,
-utm_source, Google Analytics,,
-utm_id, Google Analytics, https://support.google.com/urchin/answer/2633697,
+utm_content, Google Analytics, https://support.google.com/analytics/answer/10917952, No
+utm_term, Google Analytics, https://support.google.com/analytics/answer/10917952, No
+utm_campaign, Google Analytics, https://support.google.com/analytics/answer/10917952, No
+utm_medium, Google Analytics, https://support.google.com/analytics/answer/10917952, No
+utm_source, Google Analytics, https://support.google.com/analytics/answer/10917952, No
+utm_id, Google Analytics, https://support.google.com/analytics/answer/10917952, No
+utm_source_platform, Google Analytics, https://support.google.com/analytics/answer/10917952, No
+utm_creative_format, Google Analytics, https://support.google.com/analytics/answer/10917952, No
+utm_marketing_tactic, Google Analytics, https://support.google.com/analytics/answer/10917952, No
 _ga, Google Analytics,,
+_gl, Google Analytics, https://support.google.com/analytics/answer/10071811, Yes
 mc_cid, Mailchimp,,
 mc_eid, Mailchimp,,
 _bta_tid, Bronto, https://p.bm23.com/bta.js,
@@ -82,3 +86,4 @@ sms_source, Wunderkind, https://assets.bounceexchange.com/assets/smart-tag/versi
 sms_click, Wunderkind, https://assets.bounceexchange.com/assets/smart-tag/versioned/sms_2579b6aa71148c3eb940153c85a653a0.br.js, Yes
 sms_uph, Wunderkind, https://assets.bounceexchange.com/assets/smart-tag/versioned/sms_2579b6aa71148c3eb940153c85a653a0.br.js, Yes
 ttclid, TikTok, https://ads.tiktok.com/help/article/tiktok-click-id, Yes
+ndclid, Next Door,,Yes

--- a/_data/params.csv
+++ b/_data/params.csv
@@ -87,3 +87,4 @@ sms_click, Wunderkind, https://assets.bounceexchange.com/assets/smart-tag/versio
 sms_uph, Wunderkind, https://assets.bounceexchange.com/assets/smart-tag/versioned/sms_2579b6aa71148c3eb940153c85a653a0.br.js, Yes
 ttclid, TikTok, https://ads.tiktok.com/help/article/tiktok-click-id, Yes
 ndclid, Next Door,,Yes
+ScCid, Snapchat, https://businesshelp.snapchat.com/s/article/click-id, Yes


### PR DESCRIPTION
`ndclid` source docs are not openly accessible, but indirect evidence available (e.g. via Tealium docs) 
`ScCid` is cased exactly how it's specified on the source docs
`_gl` similar in function to `_ga`, but uses the newer gtag library
Completed the `utm_*` list as per the GA4 specs